### PR TITLE
Add more keywords and improve keyword categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change Log
+## [0.0.3] - 2022-06-06
+- Added support for new keywords and bang operators, plus more keyword categories.
+
 
 ## [0.0.2] - 2020-04-16
 - Added support for integers, code fragments and some new keywords.

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -9,7 +9,8 @@
     "brackets": [
         ["{", "}"],
         ["[", "]"],
-        ["(", ")"]
+        ["(", ")"],
+        ["<", ">"]
     ],
     // symbols that are auto closed when typing
     "autoClosingPairs": [
@@ -19,6 +20,12 @@
         ["\"", "\""],
         ["'", "'"]
     ],
+    "colorizedBracketPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["<", ">"]
+      ],
     // symbols that that can be used to surround a selection
     "surroundingPairs": [
         ["{", "}"],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "llvm-tablegen",
     "displayName": "LLVM TableGen",
     "description": "Syntax highlighting for TableGen.",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "publisher": "jakob-erzar",
     "engines": {
         "vscode": "^1.22.0"

--- a/syntaxes/tablegen.tmLanguage
+++ b/syntaxes/tablegen.tmLanguage
@@ -18,9 +18,33 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(assert|bit|bits|class|code|dag|def|else|false|foreach|defm|defset|defvar|field|in|include|int|let|list|multiclass|string|then|true)\b</string>
+			<string>\b(assert|else|foreach|if|then)\b</string>
 			<key>name</key>
 			<string>keyword.control.tablegen</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\b(def|defm|defset|defvar|include|let)\b</string>
+			<key>name</key>
+			<string>keyword.operator.tablegen</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\b(field|in)\b</string>
+			<key>name</key>
+			<string>keyword.other.tablegen</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\b(bit|bits|class|code|dag|int|list|multiclass|string)\b</string>
+			<key>name</key>
+			<string>storage.type.tablegen</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\b(false|true)\b</string>
+			<key>name</key>
+			<string>constant.language.tablegen</string>
 		</dict>
 		<dict>
 			<key>begin</key>

--- a/syntaxes/tablegen.tmLanguage
+++ b/syntaxes/tablegen.tmLanguage
@@ -47,6 +47,12 @@
 			<string>constant.language.tablegen</string>
 		</dict>
 		<dict>
+			<key>match</key>
+			<string>\b(\!add|\!and|\!cast|\!con|\!dag|\!empty|\!eq|\!filter|\!find|\!foldl|\!foreach|\!ge|\!getdagop|\!gt|\!head|\!if|\!interleave|\!isa|\!le|\!listconcat|\!listsplat|\!lt|\!mul|\!ne|\!not|\!or|\!setdagop|\!shl|\!size|\!sra|\!srl|\!strconcat|\!sub|\!subst|\!substr|\!tail|\!xor|\!cond)\b</string>
+			<key>name</key>
+			<string>support.function.tablegen</string>
+		</dict>
+		<dict>
 			<key>begin</key>
 			<string>"</string>
 			<key>end</key>

--- a/syntaxes/tablegen.tmLanguage
+++ b/syntaxes/tablegen.tmLanguage
@@ -18,7 +18,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(def|let|in|code|dag|string|list|bits|bit|field|include|defm|foreach|class|multiclass|int|if|then|else|defset|defvar)\b</string>
+			<string>\b(assert|bit|bits|class|code|dag|def|else|false|foreach|defm|defset|defvar|field|in|include|int|let|list|multiclass|string|then|true)\b</string>
 			<key>name</key>
 			<string>keyword.control.tablegen</string>
 		</dict>


### PR DESCRIPTION
per the request in #2 , added the new keywords (like true and false) and also added all the bang operators
I also attempted to categorize the types of the keywords more properly based on the definitions from this page:
https://macromates.com/manual/en/language_grammars
This would give more semantic information to the themes so that the user could color the keywords differently depending on their function.